### PR TITLE
Improve performance by removing partial application and flattening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 elm-stuff/
 .coverage/
+index.html

--- a/benchmarks/elm.json
+++ b/benchmarks/elm.json
@@ -1,0 +1,38 @@
+{
+    "type": "application",
+    "source-directories": [
+        "src",
+        "../src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/browser": "1.0.2",
+            "elm/core": "1.0.5",
+            "elm/html": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm-explorations/benchmark": "1.0.2",
+            "lue-bird/elm-alternative-benchmark-runner": "1.0.0"
+        },
+        "indirect": {
+            "BrianHicks/elm-trend": "2.1.3",
+            "avh4/elm-color": "1.0.0",
+            "elm/json": "1.1.3",
+            "elm/time": "1.0.0",
+            "elm/url": "1.0.0",
+            "elm/virtual-dom": "1.0.3",
+            "mdgriffith/elm-ui": "1.1.8",
+            "mdgriffith/style-elements": "5.0.2",
+            "miniBill/elm-ui-with-context": "1.1.0",
+            "robinheghan/murmur3": "1.0.0"
+        }
+    },
+    "test-dependencies": {
+        "direct": {
+            "elm-explorations/test": "1.2.2"
+        },
+        "indirect": {
+            "elm/random": "1.0.0"
+        }
+    }
+}

--- a/benchmarks/src/Benchmarks.elm
+++ b/benchmarks/src/Benchmarks.elm
@@ -1,0 +1,111 @@
+module Benchmarks exposing (main)
+
+import Benchmark exposing (Benchmark, describe)
+import Benchmark.Alternative exposing (rank)
+import Benchmark.Runner.Alternative as BenchmarkRunner
+import MinPriorityQueue
+import Vendor.MinPriorityQueue
+
+
+main : BenchmarkRunner.Program
+main =
+    describe "Performance changes"
+        [ insertMany
+        , toList
+        , toSortedList
+        ]
+        |> BenchmarkRunner.program
+
+
+insertMany : Benchmark
+insertMany =
+    describe "Insert many"
+        [ rank "Priority equals n"
+            (\fn -> fn ())
+            [ ( "Current"
+              , \() ->
+                    List.foldl (\n queue -> MinPriorityQueue.insert identity n queue) MinPriorityQueue.empty thousandItems
+                        |> always ()
+              )
+            , ( "Previous"
+              , \() ->
+                    List.foldl (\n queue -> Vendor.MinPriorityQueue.insert identity n queue) Vendor.MinPriorityQueue.empty thousandItems
+                        |> always ()
+              )
+            ]
+        , rank "Priority is always the same"
+            (\fn -> fn ())
+            [ ( "Current"
+              , \() ->
+                    List.foldl (\n queue -> MinPriorityQueue.insert always0 n queue) MinPriorityQueue.empty thousandItems
+                        |> always ()
+              )
+            , ( "Previous"
+              , \() ->
+                    List.foldl (\n queue -> Vendor.MinPriorityQueue.insert always0 n queue) Vendor.MinPriorityQueue.empty thousandItems
+                        |> always ()
+              )
+            ]
+        ]
+
+
+toList : Benchmark
+toList =
+    describe "toList"
+        [ rank "Priority equals n"
+            (\fn -> fn ())
+            [ ( "Current", \() -> MinPriorityQueue.toList queueWithDifferentPrioritiesCurrent )
+            , ( "Previous", \() -> Vendor.MinPriorityQueue.toList queueWithDifferentPrioritiesPrevious )
+            ]
+        , rank "Priority is always the same"
+            (\fn -> fn ())
+            [ ( "Current", \() -> MinPriorityQueue.toList queueWithSamePrioritiesCurrent )
+            , ( "Previous", \() -> Vendor.MinPriorityQueue.toList queueWithSamePrioritiesPrevious )
+            ]
+        ]
+
+
+toSortedList : Benchmark
+toSortedList =
+    describe "toSortedList"
+        [ rank "Priority equals n"
+            (\fn -> fn ())
+            [ ( "Current", \() -> MinPriorityQueue.toSortedList queueWithDifferentPrioritiesCurrent )
+            , ( "Previous", \() -> Vendor.MinPriorityQueue.toSortedList queueWithDifferentPrioritiesPrevious )
+            ]
+        , rank "Priority is always the same"
+            (\fn -> fn ())
+            [ ( "Current", \() -> MinPriorityQueue.toSortedList queueWithSamePrioritiesCurrent )
+            , ( "Previous", \() -> Vendor.MinPriorityQueue.toSortedList queueWithSamePrioritiesPrevious )
+            ]
+        ]
+
+
+queueWithDifferentPrioritiesCurrent : MinPriorityQueue.MinPriorityQueue Int
+queueWithDifferentPrioritiesCurrent =
+    MinPriorityQueue.fromList identity thousandItems
+
+
+queueWithDifferentPrioritiesPrevious : Vendor.MinPriorityQueue.MinPriorityQueue Int
+queueWithDifferentPrioritiesPrevious =
+    Vendor.MinPriorityQueue.fromList identity thousandItems
+
+
+queueWithSamePrioritiesCurrent : MinPriorityQueue.MinPriorityQueue Int
+queueWithSamePrioritiesCurrent =
+    MinPriorityQueue.fromList always0 thousandItems
+
+
+queueWithSamePrioritiesPrevious : Vendor.MinPriorityQueue.MinPriorityQueue Int
+queueWithSamePrioritiesPrevious =
+    Vendor.MinPriorityQueue.fromList always0 thousandItems
+
+
+thousandItems : List Int
+thousandItems =
+    List.range 0 1000
+
+
+always0 : a -> Int
+always0 =
+    always 0

--- a/benchmarks/src/Vendor/MaxPriorityQueue.elm
+++ b/benchmarks/src/Vendor/MaxPriorityQueue.elm
@@ -1,0 +1,394 @@
+module Vendor.MaxPriorityQueue exposing
+    ( MaxPriorityQueue
+    , empty, singleton, fromList
+    , toList, toSortedList, fold
+    , insert, enqueue, filter, dequeue, dequeueMany, largest, head, tail, take, drop
+    , all, any, isEmpty, length
+    )
+
+{-| The `(a -> Int)` function given to `singleton`, `insert`, `enqueue` and `fromList`
+is how you teach the queue to get the priority of an item. `MaxPriorityQueue` will
+prioritize items with larger Ints.
+
+@docs MaxPriorityQueue
+
+**Note:** Some functions in this module return lists of values in perhaps a slightly
+unexpected reversed order (`toSortedList`, `dequeueMany`, `take`). This is done
+in name of efficiency: there's no trick to efficiently return it in the more
+expected reverse order, so we let the user do the List.reverse themselves if
+needed and make the cost more apparent.
+
+    toSortedList (fromList identity [ 100, 3, 1, 4, 1, 5, 9, 200 ])
+        --> [ 1, 1, 3, 4, 5, 9, 100, 200 ]
+
+    List.reverse (toSortedList (fromList identity [ 100, 3, 1, 4, 1, 5, 9, 200 ]))
+        --> [ 200, 100, 9, 5, 4, 3, 1, 1 ]
+
+Anyways, let's continue with the rest of the docs!
+
+@docs empty, singleton, fromList
+@docs toList, toSortedList, fold
+@docs insert, enqueue, filter, dequeue, dequeueMany, largest, head, tail, take, drop
+@docs all, any, isEmpty, length
+
+-}
+
+import Vendor.PriorityQueue as PriorityQueue exposing (PriorityQueue)
+
+
+
+-- The schtick of this module is to be exactly like MinPriorityQueue, just replace `toPriority` with `toPriority >> negate` everywhere.
+-- Also, the better name for `head` is `largest` here, not `smallest`.
+
+
+{-| A priority queue giving the highest priority to largest Ints given by your
+`(a -> Int)` function.
+
+    MaxPriorityQueue.fromList .age
+        [ { name = "Martin", age = 31 }
+        , { name = "Xavier", age = 13 }
+        , { name = "Joanne", age = 54 }
+        ]
+        |> MaxPriorityQueue.largest
+        --> { name = "Joanne", age = 54 }
+
+Note that MaxPriorityQueue is not `(==)`-safe.
+
+-}
+type MaxPriorityQueue a
+    = MaxQ (PriorityQueue a)
+
+
+{-| Create an empty MaxPriorityQueue.
+-}
+empty : MaxPriorityQueue a
+empty =
+    MaxQ PriorityQueue.empty
+
+
+{-| Create a MaxPriorityQueue with a single element.
+
+    singleton identity 5
+        |> toList
+        --> [ 5 ]
+
+-}
+singleton : (a -> Int) -> a -> MaxPriorityQueue a
+singleton toPriority element =
+    MaxQ <| PriorityQueue.singleton (toPriority >> negate) element
+
+
+{-| Create a MaxPriorityQueue from a list of elements.
+
+    fromList identity [ 3, 1, 4, 1, 5, 9 ]
+        |> toSortedList
+        --> [ 1, 1, 3, 4, 5, 9 ]
+
+-}
+fromList : (a -> Int) -> List a -> MaxPriorityQueue a
+fromList toPriority list =
+    MaxQ <| PriorityQueue.fromList (toPriority >> negate) list
+
+
+{-| Convert a MaxPriorityQueue to a list.
+
+The order of items in the resulting list is unspecified.
+If you need a sorted list, use `toSortedList`.
+
+    toList (fromList identity [ 100, 3, 1, 4, 1, 5, 9, 200 ])
+        --> [ 200, 100, 4, 1, 1, 9, 5, 3]
+
+-}
+toList : MaxPriorityQueue a -> List a
+toList (MaxQ pq) =
+    PriorityQueue.toList pq
+
+
+{-| Convert a MaxPriorityQueue to a sorted list.
+
+The order of items in the resulting list is lowest-priority-first, thus may seem
+reversed from what you want. See note at the top.
+
+    toSortedList (fromList identity [ 100, 3, 1, 4, 1, 5, 9, 200 ])
+        --> [ 1, 1, 3, 4, 5, 9, 100, 200 ]
+
+-}
+toSortedList : MaxPriorityQueue a -> List a
+toSortedList (MaxQ pq) =
+    PriorityQueue.toSortedList pq
+
+
+{-| Fold over the elements in the MaxPriorityQueue, highest priority first.
+
+    fromList identity [ 3, 1, 4 ]
+        |> fold (\x acc -> x :: acc) []
+        --> [ 1, 3, 4 ]
+
+    fromList identity [ 3, 1, 4 ]
+        |> fold (+) 0
+        --> 8
+
+    fromList Tuple.first [ (10, "World"), (1, "Hello"), (5, "Elm") ]
+        |> fold (\(_, word) acc -> acc ++ " " ++ word) ""
+        --> " World Elm Hello"
+
+-}
+fold : (a -> b -> b) -> b -> MaxPriorityQueue a -> b
+fold f acc (MaxQ pq) =
+    PriorityQueue.fold f acc pq
+
+
+{-| Insert an element into a MaxPriorityQueue. O(log n).
+
+    empty
+        |> insert identity 3
+        |> insert identity 4
+        |> insert identity 1
+        |> largest
+        --> Just 4
+
+-}
+insert : (a -> Int) -> a -> MaxPriorityQueue a -> MaxPriorityQueue a
+insert toPriority element (MaxQ pq) =
+    MaxQ (PriorityQueue.insert (toPriority >> negate) element pq)
+
+
+{-| Insert an element into a MaxPriorityQueue. O(log n).
+
+This is an alias for `insert`.
+
+    empty
+        |> enqueue identity 3
+        |> enqueue identity 4
+        |> enqueue identity 1
+        |> largest
+        --> Just 4
+
+-}
+enqueue : (a -> Int) -> a -> MaxPriorityQueue a -> MaxPriorityQueue a
+enqueue toPriority element mpq =
+    insert toPriority element mpq
+
+
+{-| Check if a MaxPriorityQueue is empty.
+
+    isEmpty empty
+        --> True
+
+    isEmpty (singleton identity 1)
+        --> False
+
+-}
+isEmpty : MaxPriorityQueue a -> Bool
+isEmpty (MaxQ pq) =
+    PriorityQueue.isEmpty pq
+
+
+{-| Remove and return the element with the highest priority from the MaxPriorityQueue,
+along with the updated queue. Returns Nothing if the queue is empty. O(log n).
+
+    dequeue (fromList identity [ 3, 4, 1 ])
+        --> Just ( 4, fromList identity [ 3, 1 ] )
+
+    dequeue empty
+        --> Nothing
+
+-}
+dequeue : MaxPriorityQueue a -> Maybe ( a, MaxPriorityQueue a )
+dequeue (MaxQ pq) =
+    PriorityQueue.dequeue pq
+        |> Maybe.map (Tuple.mapSecond MaxQ)
+
+
+{-| Retrieve the N items with highest priority, alongside the queue without them.
+
+The order of items in the resulting list is lowest-priority-first, thus may seem
+reversed from what you want. See note at the top.
+
+    fromList identity [ 3, 1, 5, 2, 4 ]
+        |> dequeueMany 3
+        --> ( [ 3, 4, 5 ], fromList identity [ 1, 2 ] )
+
+If you take more items than are in the queue, you will get all the items in the
+queue.
+
+    fromList identity [ 3, 1, 2 ]
+        |> dequeueMany 5
+        --> ( [ 1, 2, 3 ], empty )
+
+-}
+dequeueMany : Int -> MaxPriorityQueue a -> ( List a, MaxPriorityQueue a )
+dequeueMany n (MaxQ pq) =
+    PriorityQueue.dequeueMany n pq
+        |> Tuple.mapSecond MaxQ
+
+
+{-| Keep only the elements that satisfy the predicate.
+
+    fromList identity [ 1, 2, 3, 4, 5 ]
+        |> filter (\x -> modBy 2 x == 0)
+        |> toSortedList
+        --> [ 2, 4 ]
+
+-}
+filter : (a -> Bool) -> MaxPriorityQueue a -> MaxPriorityQueue a
+filter predicate (MaxQ pq) =
+    MaxQ <| PriorityQueue.filter predicate pq
+
+
+{-| Retrieve the N items with highest priority. O(log n).
+
+The order of items in the resulting list is lowest-priority-first, thus may seem
+reversed from what you want. See note at the top.
+
+    fromList identity [ 3, 1, 5, 2, 4 ]
+        |> take 3
+        --> [ 3, 4, 5 ]
+
+If you take more items than are in the queue, you will get all the items in the
+queue.
+
+    take 1000 (singleton identity 1)
+        --> [ 1 ]
+
+-}
+take : Int -> MaxPriorityQueue a -> List a
+take n (MaxQ pq) =
+    PriorityQueue.take n pq
+
+
+{-| Drop the N items with highest priority from the queue. O(log n).
+
+    fromList identity [ 3, 1, 5, 2, 4 ]
+        |> drop 3
+        |> toSortedList
+        --> [ 1, 2 ]
+
+If you drop more items than are in the queue, you will get an empty queue.
+
+    drop 1000 (singleton identity 1)
+        --> empty
+
+-}
+drop : Int -> MaxPriorityQueue a -> MaxPriorityQueue a
+drop n (MaxQ pq) =
+    MaxQ <| PriorityQueue.drop n pq
+
+
+{-| Get the item with the highest priority without removing it from the queue.
+Returns Nothing if the queue is empty. O(1).
+
+    head (fromList identity [ 3, 4, 1 ])
+        --> Just 4
+
+    head empty
+        --> Nothing
+
+-}
+head : MaxPriorityQueue a -> Maybe a
+head (MaxQ pq) =
+    PriorityQueue.head pq
+
+
+{-| Get a new queue with the highest priority item removed.
+Returns Nothing if the queue is empty. O(log n).
+
+    tail (fromList identity [ 3, 4, 1 ])
+        |> Maybe.map toSortedList
+        --> Just [ 1, 3 ]
+
+    tail empty
+        --> Nothing
+
+-}
+tail : MaxPriorityQueue a -> Maybe (MaxPriorityQueue a)
+tail (MaxQ pq) =
+    PriorityQueue.tail pq
+        |> Maybe.map MaxQ
+
+
+{-| Get the item with the highest priority without removing it from the queue.
+Returns Nothing if the queue is empty. O(1).
+
+This is an alias for `head`.
+
+    largest (fromList identity [ 3, 4, 1 ])
+        --> Just 4
+
+    largest empty
+        --> Nothing
+
+-}
+largest : MaxPriorityQueue a -> Maybe a
+largest mpq =
+    head mpq
+
+
+{-| Determine if all elements satisfy the predicate.
+
+    fromList identity [ 1, 2, 3 ]
+        |> all (\x -> x > 10)
+        == False
+
+    fromList identity [ 9, 11 ]
+        |> all (\x -> x > 10)
+        == False
+
+    fromList identity [ 15, 16, 17 ]
+        |> all (\x -> x > 10)
+        == True
+
+    all (\_ -> True) empty --> True
+
+    all (\_ -> True) (singleton identity 1) --> True
+
+    all (\_ -> False) empty --> True
+
+    all (\_ -> False) (singleton identity 1) --> False
+
+-}
+all : (a -> Bool) -> MaxPriorityQueue a -> Bool
+all predicate (MaxQ pq) =
+    PriorityQueue.all predicate pq
+
+
+{-| Determine if any elements satisfy the predicate.
+
+    fromList identity [ 1, 2, 3 ]
+        |> any (\x -> x > 10)
+        == False
+
+    fromList identity [ 9, 11 ]
+        |> any (\x -> x > 10)
+        == True
+
+    fromList identity [ 15, 16, 17 ]
+        |> any (\x -> x > 10)
+        == True
+
+    any (\_ -> True) empty --> False
+
+    any (\_ -> True) (singleton identity 1) --> True
+
+    any (\_ -> False) empty --> False
+
+    any (\_ -> False) (singleton identity 1) --> False
+
+-}
+any : (a -> Bool) -> MaxPriorityQueue a -> Bool
+any predicate (MaxQ pq) =
+    PriorityQueue.any predicate pq
+
+
+{-| Get the number of elements in the queue. O(1).
+
+    length (fromList identity [ 1, 2, 3 ])
+        --> 3
+
+    length empty
+        --> 0
+
+-}
+length : MaxPriorityQueue a -> Int
+length (MaxQ pq) =
+    PriorityQueue.length pq

--- a/benchmarks/src/Vendor/MinPriorityQueue.elm
+++ b/benchmarks/src/Vendor/MinPriorityQueue.elm
@@ -1,0 +1,389 @@
+module Vendor.MinPriorityQueue exposing
+    ( MinPriorityQueue
+    , empty, singleton, fromList
+    , toList, toSortedList, fold
+    , insert, enqueue, filter, dequeue, dequeueMany, smallest, head, tail, take, drop
+    , all, any, isEmpty, length
+    )
+
+{-| The `(a -> Int)` function given to `singleton`, `insert`, `enqueue` and `fromList`
+is how you teach the queue to get the priority of an item. `MinPriorityQueue` will
+prioritize items with smaller Ints.
+
+@docs MinPriorityQueue
+
+**Note:** Some functions in this module return lists of values in perhaps a slightly
+unexpected reversed order (`toSortedList`, `dequeueMany`, `take`). This is done
+in name of efficiency: there's no trick to efficiently return it in the more
+expected reverse order, so we let the user do the List.reverse themselves if
+needed and make the cost more apparent.
+
+    toSortedList (fromList identity [ 100, 3, 1, 4, 1, 5, 9, 200 ])
+        --> [ 200, 100, 9, 5, 4, 3, 1, 1 ]
+
+    List.reverse (toSortedList (fromList identity [ 100, 3, 1, 4, 1, 5, 9, 200 ]))
+        --> [ 1, 1, 3, 4, 5, 9, 100, 200 ]
+
+Anyways, let's continue with the rest of the docs!
+
+@docs empty, singleton, fromList
+@docs toList, toSortedList, fold
+@docs insert, enqueue, filter, dequeue, dequeueMany, smallest, head, tail, take, drop
+@docs all, any, isEmpty, length
+
+-}
+
+import Vendor.PriorityQueue as PriorityQueue exposing (PriorityQueue)
+
+
+{-| A priority queue giving the highest priority to smallest Ints given by your
+`(a -> Int)` function.
+
+    MinPriorityQueue.fromList .age
+        [ { name = "Martin", age = 31 }
+        , { name = "Xavier", age = 13 }
+        , { name = "Joanne", age = 54 }
+        ]
+        |> MinPriorityQueue.smallest
+        --> { name = "Xavier", age = 13 }
+
+Note that MinPriorityQueue is not `(==)`-safe.
+
+-}
+type MinPriorityQueue a
+    = MinQ (PriorityQueue a)
+
+
+{-| Create an empty MinPriorityQueue.
+-}
+empty : MinPriorityQueue a
+empty =
+    MinQ PriorityQueue.empty
+
+
+{-| Create a MinPriorityQueue with a single element.
+
+    singleton identity 5
+        |> toList
+        --> [ 5 ]
+
+-}
+singleton : (a -> Int) -> a -> MinPriorityQueue a
+singleton toPriority element =
+    MinQ <| PriorityQueue.singleton toPriority element
+
+
+{-| Create a MinPriorityQueue from a list of elements.
+
+    fromList identity [ 3, 1, 4, 1, 5, 9 ]
+        |> toSortedList
+        --> [ 1, 1, 3, 4, 5, 9 ]
+
+-}
+fromList : (a -> Int) -> List a -> MinPriorityQueue a
+fromList toPriority list =
+    MinQ <| PriorityQueue.fromList toPriority list
+
+
+{-| Convert a MinPriorityQueue to a list.
+
+The order of items in the resulting list is unspecified.
+If you need a sorted list, use `toSortedList`.
+
+    toList (fromList identity [ 100, 3, 1, 4, 1, 5, 9, 200 ])
+        --> [ 1, 1, 3, 100, 4, 5, 9, 200 ]
+
+-}
+toList : MinPriorityQueue a -> List a
+toList (MinQ pq) =
+    PriorityQueue.toList pq
+
+
+{-| Convert a MinPriorityQueue to a sorted list.
+
+The order of items in the resulting list is lowest-priority-first, thus may seem
+reversed from what you want. See note at the top.
+
+    toSortedList (fromList identity [ 100, 3, 1, 4, 1, 5, 9, 200 ])
+        --> [ 200, 100, 9, 5, 4, 3, 1, 1 ]
+
+-}
+toSortedList : MinPriorityQueue a -> List a
+toSortedList (MinQ pq) =
+    PriorityQueue.toSortedList pq
+
+
+{-| Fold over the elements in the MinPriorityQueue, highest priority first.
+
+    fromList identity [ 3, 1, 4 ]
+        |> fold (\x acc -> x :: acc) []
+        --> [ 4, 3, 1 ]
+
+    fromList identity [ 3, 1, 4 ]
+        |> fold (+) 0
+        --> 8
+
+    fromList Tuple.first [ (10, "World"), (1, "Hello"), (5, "Elm") ]
+        |> fold (\(_, word) acc -> acc ++ " " ++ word) ""
+        --> " Hello Elm World"
+
+-}
+fold : (a -> b -> b) -> b -> MinPriorityQueue a -> b
+fold f acc (MinQ pq) =
+    PriorityQueue.fold f acc pq
+
+
+{-| Insert an element into a MinPriorityQueue. O(log n).
+
+    empty
+        |> insert identity 3
+        |> insert identity 1
+        |> insert identity 4
+        |> smallest
+        --> Just 1
+
+-}
+insert : (a -> Int) -> a -> MinPriorityQueue a -> MinPriorityQueue a
+insert toPriority element (MinQ pq) =
+    MinQ (PriorityQueue.insert toPriority element pq)
+
+
+{-| Insert an element into a MinPriorityQueue. O(log n).
+
+This is an alias for `insert`.
+
+    empty
+        |> enqueue identity 3
+        |> enqueue identity 1
+        |> enqueue identity 4
+        |> smallest
+        --> Just 1
+
+-}
+enqueue : (a -> Int) -> a -> MinPriorityQueue a -> MinPriorityQueue a
+enqueue toPriority element mpq =
+    insert toPriority element mpq
+
+
+{-| Check if a MinPriorityQueue is empty.
+
+    isEmpty empty
+        --> True
+
+    isEmpty (singleton identity 1)
+        --> False
+
+-}
+isEmpty : MinPriorityQueue a -> Bool
+isEmpty (MinQ pq) =
+    PriorityQueue.isEmpty pq
+
+
+{-| Remove and return the element with the highest priority from the MinPriorityQueue,
+along with the updated queue. Returns Nothing if the queue is empty. O(log n).
+
+    dequeue (fromList identity [ 3, 1, 4 ])
+        --> Just ( 1, fromList identity [ 3, 4 ] )
+
+    dequeue empty
+        --> Nothing
+
+-}
+dequeue : MinPriorityQueue a -> Maybe ( a, MinPriorityQueue a )
+dequeue (MinQ pq) =
+    PriorityQueue.dequeue pq
+        |> Maybe.map (Tuple.mapSecond MinQ)
+
+
+{-| Retrieve the N items with highest priority, alongside the queue without them.
+
+The order of items in the resulting list is lowest-priority-first, thus may seem
+reversed from what you want. See note at the top.
+
+    fromList identity [ 3, 1, 5, 2, 4 ]
+        |> dequeueMany 3
+        --> ( [ 3, 2, 1 ], fromList identity [ 5, 4 ] )
+
+If you take more items than are in the queue, you will get all the items in the
+queue.
+
+    fromList identity [ 3, 1, 2 ]
+        |> dequeueMany 5
+        --> ( [ 3, 2, 1 ], empty )
+
+-}
+dequeueMany : Int -> MinPriorityQueue a -> ( List a, MinPriorityQueue a )
+dequeueMany n (MinQ pq) =
+    PriorityQueue.dequeueMany n pq
+        |> Tuple.mapSecond MinQ
+
+
+{-| Keep only the elements that satisfy the predicate.
+
+    fromList identity [ 1, 2, 3, 4, 5 ]
+        |> filter (\x -> modBy 2 x == 0)
+        |> toSortedList
+        --> [ 4, 2 ]
+
+-}
+filter : (a -> Bool) -> MinPriorityQueue a -> MinPriorityQueue a
+filter predicate (MinQ pq) =
+    MinQ <| PriorityQueue.filter predicate pq
+
+
+{-| Retrieve the N items with highest priority. O(log n).
+
+The order of items in the resulting list is lowest-priority-first, thus may seem
+reversed from what you want. See note at the top.
+
+    fromList identity [ 3, 1, 5, 2, 4 ]
+        |> take 3
+        --> [ 3, 2, 1 ]
+
+If you take more items than are in the queue, you will get all the items in the
+queue.
+
+    take 1000 (singleton identity 1)
+        --> [ 1 ]
+
+-}
+take : Int -> MinPriorityQueue a -> List a
+take n (MinQ pq) =
+    PriorityQueue.take n pq
+
+
+{-| Drop the N items with highest priority from the queue. O(log n).
+
+    fromList identity [ 3, 1, 5, 2, 4 ]
+        |> drop 3
+        |> toSortedList
+        --> [ 5, 4 ]
+
+If you drop more items than are in the queue, you will get an empty queue.
+
+    drop 1000 (singleton identity 1)
+        --> empty
+
+-}
+drop : Int -> MinPriorityQueue a -> MinPriorityQueue a
+drop n (MinQ pq) =
+    MinQ <| PriorityQueue.drop n pq
+
+
+{-| Get the item with the highest priority without removing it from the queue.
+Returns Nothing if the queue is empty. O(1).
+
+    head (fromList identity [ 3, 1, 4 ])
+        --> Just 1
+
+    head empty
+        --> Nothing
+
+-}
+head : MinPriorityQueue a -> Maybe a
+head (MinQ pq) =
+    PriorityQueue.head pq
+
+
+{-| Get a new queue with the highest priority item removed.
+Returns Nothing if the queue is empty. O(log n).
+
+    tail (fromList identity [ 3, 1, 4 ])
+        |> Maybe.map toSortedList
+        --> Just [ 4, 3 ]
+
+    tail empty
+        --> Nothing
+
+-}
+tail : MinPriorityQueue a -> Maybe (MinPriorityQueue a)
+tail (MinQ pq) =
+    PriorityQueue.tail pq
+        |> Maybe.map MinQ
+
+
+{-| Get the item with the highest priority without removing it from the queue.
+Returns Nothing if the queue is empty. O(1).
+
+This is an alias for `head`.
+
+    smallest (fromList identity [ 3, 1, 4 ])
+        --> Just 1
+
+    smallest empty
+        --> Nothing
+
+-}
+smallest : MinPriorityQueue a -> Maybe a
+smallest mpq =
+    head mpq
+
+
+{-| Determine if all elements satisfy the predicate.
+
+    fromList identity [ 1, 2, 3 ]
+        |> all (\x -> x > 10)
+        == False
+
+    fromList identity [ 9, 11 ]
+        |> all (\x -> x > 10)
+        == False
+
+    fromList identity [ 15, 16, 17 ]
+        |> all (\x -> x > 10)
+        == True
+
+    all (\_ -> True) empty --> True
+
+    all (\_ -> True) (singleton identity 1) --> True
+
+    all (\_ -> False) empty --> True
+
+    all (\_ -> False) (singleton identity 1) --> False
+
+-}
+all : (a -> Bool) -> MinPriorityQueue a -> Bool
+all predicate (MinQ pq) =
+    PriorityQueue.all predicate pq
+
+
+{-| Determine if any elements satisfy the predicate.
+
+    fromList identity [ 1, 2, 3 ]
+        |> any (\x -> x > 10)
+        == False
+
+    fromList identity [ 9, 11 ]
+        |> any (\x -> x > 10)
+        == True
+
+    fromList identity [ 15, 16, 17 ]
+        |> any (\x -> x > 10)
+        == True
+
+    any (\_ -> True) empty --> False
+
+    any (\_ -> True) (singleton identity 1) --> True
+
+    any (\_ -> False) empty --> False
+
+    any (\_ -> False) (singleton identity 1) --> False
+
+-}
+any : (a -> Bool) -> MinPriorityQueue a -> Bool
+any predicate (MinQ pq) =
+    PriorityQueue.any predicate pq
+
+
+{-| Get the number of elements in the queue. O(1).
+
+    length (fromList identity [ 1, 2, 3 ])
+        --> 3
+
+    length empty
+        --> 0
+
+-}
+length : MinPriorityQueue a -> Int
+length (MinQ pq) =
+    PriorityQueue.length pq

--- a/benchmarks/src/Vendor/PriorityQueue.elm
+++ b/benchmarks/src/Vendor/PriorityQueue.elm
@@ -1,0 +1,320 @@
+module Vendor.PriorityQueue exposing
+    ( PriorityQueue
+    , empty, singleton, fromList
+    , toList, toSortedList, fold
+    , insert, filter, dequeue, dequeueMany, head, tail, take, drop
+    , all, any, isEmpty, length
+    )
+
+{-|
+
+@docs PriorityQueue
+@docs empty, singleton, fromList
+@docs toList, toSortedList, fold
+@docs insert, filter, dequeue, dequeueMany, head, tail, take, drop
+@docs all, any, isEmpty, length
+
+-}
+
+
+type alias Rank =
+    Int
+
+
+type alias Length =
+    Int
+
+
+type alias Priority =
+    Int
+
+
+{-| heap-ordered binary tree with the _leftist property_
+
+The leftist property is that the _rank_ of any left child is at least as large as that of its right sibling. The rank of a node is defined as the length of its _right spine_, i.e. the right-most path of the node in question to an empty node.
+
+-}
+type PriorityQueue a
+    = Empty
+    | Node Rank Length ( a, Priority ) (PriorityQueue a) (PriorityQueue a)
+
+
+empty : PriorityQueue a
+empty =
+    Empty
+
+
+singleton : (a -> Priority) -> a -> PriorityQueue a
+singleton toPriority x =
+    Node 1 1 ( x, toPriority x ) Empty Empty
+
+
+fromList : (a -> Priority) -> List a -> PriorityQueue a
+fromList toPriority xs =
+    xs
+        |> List.foldl (insert toPriority) empty
+
+
+filter : (a -> Bool) -> PriorityQueue a -> PriorityQueue a
+filter pred q =
+    case q of
+        Empty ->
+            q
+
+        Node r _ ( element, p ) a b ->
+            if pred element then
+                let
+                    filteredA : PriorityQueue a
+                    filteredA =
+                        filter pred a
+
+                    filteredB : PriorityQueue a
+                    filteredB =
+                        filter pred b
+
+                    lengthA : Int
+                    lengthA =
+                        length filteredA
+
+                    lengthB : Int
+                    lengthB =
+                        length filteredB
+                in
+                Node r (1 + lengthA + lengthB) ( element, p ) filteredA filteredB
+
+            else
+                merge (filter pred a) (filter pred b)
+
+
+dequeue : PriorityQueue a -> Maybe ( a, PriorityQueue a )
+dequeue q =
+    case q of
+        Empty ->
+            Nothing
+
+        Node _ _ ( element, _ ) a b ->
+            Just ( element, merge a b )
+
+
+dequeueMany : Int -> PriorityQueue a -> ( List a, PriorityQueue a )
+dequeueMany n q =
+    let
+        go : Int -> PriorityQueue a -> List a -> ( List a, PriorityQueue a )
+        go nn qq acc =
+            if nn <= 0 then
+                ( acc, qq )
+
+            else
+                case dequeue qq of
+                    Nothing ->
+                        ( acc, qq )
+
+                    Just ( x, q__ ) ->
+                        go (nn - 1) q__ (x :: acc)
+    in
+    go n q []
+
+
+toList : PriorityQueue a -> List a
+toList q =
+    case q of
+        Empty ->
+            []
+
+        Node _ _ ( element, _ ) a b ->
+            element :: (toList a ++ toList b)
+
+
+toSortedList : PriorityQueue a -> List a
+toSortedList q =
+    let
+        go : PriorityQueue a -> List a -> List a
+        go qq acc =
+            case qq of
+                Empty ->
+                    acc
+
+                Node _ _ ( element, _ ) a b ->
+                    go (merge a b) (element :: acc)
+    in
+    go q []
+
+
+insert : (a -> Priority) -> a -> PriorityQueue a -> PriorityQueue a
+insert toPriority x q =
+    let
+        xq : PriorityQueue a
+        xq =
+            singleton toPriority x
+    in
+    merge xq q
+
+
+isEmpty : PriorityQueue a -> Bool
+isEmpty q =
+    case q of
+        Empty ->
+            True
+
+        Node _ _ _ _ _ ->
+            False
+
+
+head : PriorityQueue a -> Maybe a
+head q =
+    case q of
+        Empty ->
+            Nothing
+
+        Node _ _ ( element, _ ) _ _ ->
+            Just element
+
+
+tail : PriorityQueue a -> Maybe (PriorityQueue a)
+tail q =
+    case q of
+        Empty ->
+            Nothing
+
+        Node _ _ _ a b ->
+            Just <| merge a b
+
+
+take : Int -> PriorityQueue a -> List a
+take n q =
+    let
+        go : Int -> PriorityQueue a -> List a -> List a
+        go n_ q_ acc =
+            if n_ <= 0 then
+                acc
+
+            else
+                case dequeue q_ of
+                    Nothing ->
+                        acc
+
+                    Just ( x, q__ ) ->
+                        go (n_ - 1) q__ (x :: acc)
+    in
+    go n q []
+
+
+drop : Int -> PriorityQueue a -> PriorityQueue a
+drop n q =
+    if n <= 0 then
+        q
+
+    else
+        case q of
+            Empty ->
+                q
+
+            Node _ _ _ a b ->
+                drop (n - 1) (merge a b)
+
+
+all : (a -> Bool) -> PriorityQueue a -> Bool
+all pred q =
+    let
+        go : PriorityQueue a -> Bool
+        go queue =
+            case queue of
+                Empty ->
+                    True
+
+                Node _ _ ( element, _ ) a b ->
+                    if pred element then
+                        go (merge a b)
+
+                    else
+                        False
+    in
+    go q
+
+
+any : (a -> Bool) -> PriorityQueue a -> Bool
+any pred q =
+    let
+        go : PriorityQueue a -> Bool
+        go queue =
+            case queue of
+                Empty ->
+                    False
+
+                Node _ _ ( element, _ ) a b ->
+                    if pred element then
+                        True
+
+                    else
+                        go (merge a b)
+    in
+    go q
+
+
+length : PriorityQueue a -> Int
+length q =
+    case q of
+        Empty ->
+            0
+
+        Node _ l _ _ _ ->
+            l
+
+
+fold : (a -> b -> b) -> b -> PriorityQueue a -> b
+fold f acc q =
+    case q of
+        Empty ->
+            acc
+
+        Node _ _ ( element, _ ) a b ->
+            fold f (f element acc) (merge a b)
+
+
+
+-- HELPERS
+
+
+{-| Merge two trees while maintaining the _leftist property_
+-}
+merge : PriorityQueue a -> PriorityQueue a -> PriorityQueue a
+merge left right =
+    case ( left, right ) of
+        ( Empty, _ ) ->
+            right
+
+        ( _, Empty ) ->
+            left
+
+        ( Node _ _ ( x, xp ) a b, Node _ _ ( y, yp ) u v ) ->
+            if xp <= yp then
+                make ( x, xp ) a (merge b right)
+
+            else
+                make ( y, yp ) u (merge left v)
+
+
+{-| Create a non empty tree from an element and two sub-trees, keeping the _leftist property_ intact.
+-}
+make : ( a, Priority ) -> PriorityQueue a -> PriorityQueue a -> PriorityQueue a
+make x a b =
+    let
+        len : Int
+        len =
+            1 + length a + length b
+    in
+    if rank a >= rank b then
+        Node (1 + rank b) len x a b
+
+    else
+        Node (1 + rank a) len x b a
+
+
+rank : PriorityQueue a -> Rank
+rank q =
+    case q of
+        Empty ->
+            0
+
+        Node r _ _ _ _ ->
+            r

--- a/src/PriorityQueue.elm
+++ b/src/PriorityQueue.elm
@@ -52,7 +52,7 @@ singleton toPriority x =
 fromList : (a -> Priority) -> List a -> PriorityQueue a
 fromList toPriority xs =
     xs
-        |> List.foldl (insert toPriority) empty
+        |> List.foldl (\x q -> insert toPriority x q) empty
 
 
 filter : (a -> Bool) -> PriorityQueue a -> PriorityQueue a

--- a/src/PriorityQueue.elm
+++ b/src/PriorityQueue.elm
@@ -36,7 +36,7 @@ The leftist property is that the _rank_ of any left child is at least as large a
 -}
 type PriorityQueue a
     = Empty
-    | Node Rank Length ( a, Priority ) (PriorityQueue a) (PriorityQueue a)
+    | Node Rank Length a Priority (PriorityQueue a) (PriorityQueue a)
 
 
 empty : PriorityQueue a
@@ -46,7 +46,7 @@ empty =
 
 singleton : (a -> Priority) -> a -> PriorityQueue a
 singleton toPriority x =
-    Node 1 1 ( x, toPriority x ) Empty Empty
+    Node 1 1 x (toPriority x) Empty Empty
 
 
 fromList : (a -> Priority) -> List a -> PriorityQueue a
@@ -61,7 +61,7 @@ filter pred q =
         Empty ->
             q
 
-        Node r _ ( element, p ) a b ->
+        Node r _ element p a b ->
             if pred element then
                 let
                     filteredA : PriorityQueue a
@@ -80,7 +80,7 @@ filter pred q =
                     lengthB =
                         length filteredB
                 in
-                Node r (1 + lengthA + lengthB) ( element, p ) filteredA filteredB
+                Node r (1 + lengthA + lengthB) element p filteredA filteredB
 
             else
                 merge (filter pred a) (filter pred b)
@@ -92,7 +92,7 @@ dequeue q =
         Empty ->
             Nothing
 
-        Node _ _ ( element, _ ) a b ->
+        Node _ _ element _ a b ->
             Just ( element, merge a b )
 
 
@@ -121,7 +121,7 @@ toList q =
         Empty ->
             []
 
-        Node _ _ ( element, _ ) a b ->
+        Node _ _ element _ a b ->
             element :: (toList a ++ toList b)
 
 
@@ -134,7 +134,7 @@ toSortedList q =
                 Empty ->
                     acc
 
-                Node _ _ ( element, _ ) a b ->
+                Node _ _ element _ a b ->
                     go (merge a b) (element :: acc)
     in
     go q []
@@ -156,7 +156,7 @@ isEmpty q =
         Empty ->
             True
 
-        Node _ _ _ _ _ ->
+        Node _ _ _ _ _ _ ->
             False
 
 
@@ -166,7 +166,7 @@ head q =
         Empty ->
             Nothing
 
-        Node _ _ ( element, _ ) _ _ ->
+        Node _ _ element _ _ _ ->
             Just element
 
 
@@ -176,7 +176,7 @@ tail q =
         Empty ->
             Nothing
 
-        Node _ _ _ a b ->
+        Node _ _ _ _ a b ->
             Just <| merge a b
 
 
@@ -209,7 +209,7 @@ drop n q =
             Empty ->
                 q
 
-            Node _ _ _ a b ->
+            Node _ _ _ _ a b ->
                 drop (n - 1) (merge a b)
 
 
@@ -222,7 +222,7 @@ all pred q =
                 Empty ->
                     True
 
-                Node _ _ ( element, _ ) a b ->
+                Node _ _ element _ a b ->
                     if pred element then
                         go (merge a b)
 
@@ -241,7 +241,7 @@ any pred q =
                 Empty ->
                     False
 
-                Node _ _ ( element, _ ) a b ->
+                Node _ _ element _ a b ->
                     if pred element then
                         True
 
@@ -257,7 +257,7 @@ length q =
         Empty ->
             0
 
-        Node _ l _ _ _ ->
+        Node _ l _ _ _ _ ->
             l
 
 
@@ -267,7 +267,7 @@ fold f acc q =
         Empty ->
             acc
 
-        Node _ _ ( element, _ ) a b ->
+        Node _ _ element _ a b ->
             fold f (f element acc) (merge a b)
 
 
@@ -286,28 +286,28 @@ merge left right =
         ( _, Empty ) ->
             left
 
-        ( Node _ _ ( x, xp ) a b, Node _ _ ( y, yp ) u v ) ->
+        ( Node _ _ x xp a b, Node _ _ y yp u v ) ->
             if xp <= yp then
-                make ( x, xp ) a (merge b right)
+                make x xp a (merge b right)
 
             else
-                make ( y, yp ) u (merge left v)
+                make y yp u (merge left v)
 
 
 {-| Create a non empty tree from an element and two sub-trees, keeping the _leftist property_ intact.
 -}
-make : ( a, Priority ) -> PriorityQueue a -> PriorityQueue a -> PriorityQueue a
-make x a b =
+make : a -> Priority -> PriorityQueue a -> PriorityQueue a -> PriorityQueue a
+make x xp a b =
     let
         len : Int
         len =
             1 + length a + length b
     in
     if rank a >= rank b then
-        Node (1 + rank b) len x a b
+        Node (1 + rank b) len x xp a b
 
     else
-        Node (1 + rank a) len x b a
+        Node (1 + rank a) len x xp b a
 
 
 rank : PriorityQueue a -> Rank
@@ -316,5 +316,5 @@ rank q =
         Empty ->
             0
 
-        Node r _ _ _ _ ->
+        Node r _ _ _ _ _ ->
             r

--- a/src/PriorityQueue.elm
+++ b/src/PriorityQueue.elm
@@ -35,18 +35,18 @@ The leftist property is that the _rank_ of any left child is at least as large a
 
 -}
 type PriorityQueue a
-    = Empty
+    = Empty () () () () () ()
     | Node Rank Length a Priority (PriorityQueue a) (PriorityQueue a)
 
 
 empty : PriorityQueue a
 empty =
-    Empty
+    Empty () () () () () ()
 
 
 singleton : (a -> Priority) -> a -> PriorityQueue a
 singleton toPriority x =
-    Node 1 1 x (toPriority x) Empty Empty
+    Node 1 1 x (toPriority x) empty empty
 
 
 fromList : (a -> Priority) -> List a -> PriorityQueue a
@@ -58,7 +58,7 @@ fromList toPriority xs =
 filter : (a -> Bool) -> PriorityQueue a -> PriorityQueue a
 filter pred q =
     case q of
-        Empty ->
+        Empty _ _ _ _ _ _ ->
             q
 
         Node r _ element p a b ->
@@ -89,7 +89,7 @@ filter pred q =
 dequeue : PriorityQueue a -> Maybe ( a, PriorityQueue a )
 dequeue q =
     case q of
-        Empty ->
+        Empty _ _ _ _ _ _ ->
             Nothing
 
         Node _ _ element _ a b ->
@@ -118,7 +118,7 @@ dequeueMany n q =
 toList : PriorityQueue a -> List a
 toList q =
     case q of
-        Empty ->
+        Empty _ _ _ _ _ _ ->
             []
 
         Node _ _ element _ a b ->
@@ -131,7 +131,7 @@ toSortedList q =
         go : PriorityQueue a -> List a -> List a
         go qq acc =
             case qq of
-                Empty ->
+                Empty _ _ _ _ _ _ ->
                     acc
 
                 Node _ _ element _ a b ->
@@ -153,7 +153,7 @@ insert toPriority x q =
 isEmpty : PriorityQueue a -> Bool
 isEmpty q =
     case q of
-        Empty ->
+        Empty _ _ _ _ _ _ ->
             True
 
         Node _ _ _ _ _ _ ->
@@ -163,7 +163,7 @@ isEmpty q =
 head : PriorityQueue a -> Maybe a
 head q =
     case q of
-        Empty ->
+        Empty _ _ _ _ _ _ ->
             Nothing
 
         Node _ _ element _ _ _ ->
@@ -173,7 +173,7 @@ head q =
 tail : PriorityQueue a -> Maybe (PriorityQueue a)
 tail q =
     case q of
-        Empty ->
+        Empty _ _ _ _ _ _ ->
             Nothing
 
         Node _ _ _ _ a b ->
@@ -206,7 +206,7 @@ drop n q =
 
     else
         case q of
-            Empty ->
+            Empty _ _ _ _ _ _ ->
                 q
 
             Node _ _ _ _ a b ->
@@ -219,7 +219,7 @@ all pred q =
         go : PriorityQueue a -> Bool
         go queue =
             case queue of
-                Empty ->
+                Empty _ _ _ _ _ _ ->
                     True
 
                 Node _ _ element _ a b ->
@@ -238,7 +238,7 @@ any pred q =
         go : PriorityQueue a -> Bool
         go queue =
             case queue of
-                Empty ->
+                Empty _ _ _ _ _ _ ->
                     False
 
                 Node _ _ element _ a b ->
@@ -254,7 +254,7 @@ any pred q =
 length : PriorityQueue a -> Int
 length q =
     case q of
-        Empty ->
+        Empty _ _ _ _ _ _ ->
             0
 
         Node _ l _ _ _ _ ->
@@ -264,7 +264,7 @@ length q =
 fold : (a -> b -> b) -> b -> PriorityQueue a -> b
 fold f acc q =
     case q of
-        Empty ->
+        Empty _ _ _ _ _ _ ->
             acc
 
         Node _ _ element _ a b ->
@@ -280,10 +280,10 @@ fold f acc q =
 merge : PriorityQueue a -> PriorityQueue a -> PriorityQueue a
 merge left right =
     case ( left, right ) of
-        ( Empty, _ ) ->
+        ( Empty _ _ _ _ _ _, _ ) ->
             right
 
-        ( _, Empty ) ->
+        ( _, Empty _ _ _ _ _ _ ) ->
             left
 
         ( Node _ _ x xp a b, Node _ _ y yp u v ) ->
@@ -313,7 +313,7 @@ make x xp a b =
 rank : PriorityQueue a -> Rank
 rank q =
     case q of
-        Empty ->
+        Empty _ _ _ _ _ _ ->
             0
 
         Node r _ _ _ _ _ ->


### PR DESCRIPTION
This improves performance by up to 2x in certain situations.

![image](https://github.com/user-attachments/assets/64007021-ca3d-4bc4-a586-54c28a026621)

3 changes:
- Flattened the `( a, Priority )` in the `Node` variant
- Pad `Empty` variant to have the same shape as the `Node` variant
- Don't apply function partially in `fromList` (not benchmarked)

I've added some benchmarks, which are unfortunately quite slow to run. I don't know how to speed it up, maybe split each up into different `main`?
I'm comparing with the previously published version (`1.1.0`), which I naively copied and then prefixed with `Vendor.`.